### PR TITLE
Pass context at the right time, fix errors missing stack traces

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -118,7 +118,7 @@ export const createMatchError = (
   const stack = trace.withSource(trace.items[0]);
   const text = stack.sourceFile?.text!;
   // const header = `Unhandled Internal Exception\n\n`;
-  const footer = `${style("This error was caused by", yellow)} 👇\n`;
+  const footer = `${style("This error was caused by", yellow)} 👇\n\n`;
 
   let column = stack.column!;
   let line = stack.line!;

--- a/src/executors.ts
+++ b/src/executors.ts
@@ -14,23 +14,22 @@ import {
 import { Procedure } from "./procedure";
 import { last, to, style } from "./utils";
 import { bold } from "chalk";
+import { Context } from "./context";
 
 const hasErrorHandler = (op: Operation) => !!op.onError;
 
-const handleError = async (op: Operation, err: Error) => {
+const handleError = async (op: Operation, err: Error, context: Context) => {
   if (!op.onError) return err;
-  const [error, result] = await to(op.onError(err, op.context));
+  const [error, result] = await to(op.onError(err, context));
   if (error) return error;
   if (result) {
-    Object.assign(op.context, result);
+    Object.assign(context, result);
   }
 };
 
-const validate: OperationExecutor<Validate> = async (op) => {
-  const [err, result] = await to(
-    Promise.resolve(op.run(op.context[op.argKey]))
-  );
-  if (err) return await handleError(op, err);
+const validate: OperationExecutor<Validate> = async (op, context) => {
+  const [err, result] = await to(Promise.resolve(op.run(context[op.argKey])));
+  if (err) return await handleError(op, err, context);
   if (!result)
     throw createError(
       op.stackSource,
@@ -41,22 +40,22 @@ const validate: OperationExecutor<Validate> = async (op) => {
     );
 };
 
-const update: OperationExecutor<Update> = async (op) => {
+const update: OperationExecutor<Update> = async (op, context) => {
   try {
     const [err, result] = await to(
-      Promise.resolve(op.run(op.context[op.argKey], op.context))
+      Promise.resolve(op.run(context[op.argKey], context))
     );
-    if (err) return await handleError(op, err);
-    op.context[op.argKey] = result;
+    if (err) return await handleError(op, err, context);
+    context[op.argKey] = result;
   } catch (err) {
-    return await handleError(op, err);
+    return await handleError(op, err, context);
   }
 };
 
-const load: OperationExecutor<Load> = async (op) => {
-  const [err, context] = await to(Promise.resolve(op.run(op.context)));
+const load: OperationExecutor<Load> = async (op, context) => {
+  const [err, newContext] = await to(Promise.resolve(op.run(context)));
   if (err && hasErrorHandler(op)) {
-    return await handleError(op, err);
+    return await handleError(op, err, context);
   } else if (err) {
     const { name } = op.run;
     let trace = new StackTracey(err);
@@ -68,11 +67,11 @@ const load: OperationExecutor<Load> = async (op) => {
     }
     throw createError(op.stackSource, err, "oops", trace);
   } else {
-    Object.assign(op.context, context);
+    Object.assign(context, newContext);
   }
 };
 
-const match: OperationExecutor<Match> = async (op) => {
+const match: OperationExecutor<Match> = async (op, context) => {
   statementLoop: for (let [
     statementNum,
     statement,
@@ -80,16 +79,19 @@ const match: OperationExecutor<Match> = async (op) => {
     const conditions = statement.slice(0, -1) as MatchCondition<any>[];
     const action = last(statement) as MatchAction<any>;
     for (let [index, condition] of conditions.entries()) {
-      let [err, result] = await to(condition(op.context));
+      let [err, result] = await to(condition(context));
       if (err) {
-        const temp = await handleError(op, err);
+        const temp = await handleError(op, err, context);
         if (temp instanceof Error) {
+          const [message, ...details] = temp.toString().split("\n");
+          const stack = details.join("\n") || temp.stack || "";
           throw createMatchError(
             { type: "statement", index, pos: statementNum },
             op.stackSource,
             op.procedure,
-            "boop",
-            "boop"
+            message.trim().replace(/\d+ \|/, ""),
+            ERROR.MATCH_CHECK_ERR(condition.name),
+            stack.trim()
           );
         }
         return temp;
@@ -97,37 +99,38 @@ const match: OperationExecutor<Match> = async (op) => {
       if (!result) continue statementLoop;
     }
     let [err, result] = await to(
-      action instanceof Procedure ? action.exec(op.context) : action(op.context)
+      action instanceof Procedure ? action.exec(context) : action(context)
     );
     if (err) {
-      const temp = await handleError(op, err);
+      const temp = await handleError(op, err, context);
       if (temp instanceof Error) {
         const [message, ...details] = temp.toString().split("\n");
+        const stack = details.join("\n") || temp.stack || "";
         throw createMatchError(
           { type: "statement", index: statement.length - 1, pos: statementNum },
           op.stackSource,
           op.procedure,
           message.trim().replace(/\d+ \|/, ""),
           ERROR.MATCH_CHECK_ERR(action.name),
-          details.join("\n")
+          stack.trim()
         );
       }
       result = temp;
     }
     if (result) {
-      Object.assign(op.context, result);
+      Object.assign(context, result);
     }
     return;
   }
   if (op.otherwise) {
     const [err, result] = await to(
       op.otherwise instanceof Procedure
-        ? op.otherwise.exec(op.context)
-        : op.otherwise(op.context)
+        ? op.otherwise.exec(context)
+        : op.otherwise(context)
     );
-    if (err) return await handleError(op, err);
+    if (err) return await handleError(op, err, context);
     if (result) {
-      Object.assign(op.context, result);
+      Object.assign(context, result);
     }
   } else {
     throw createError(
@@ -138,23 +141,23 @@ const match: OperationExecutor<Match> = async (op) => {
   }
 };
 
-const doEx: OperationExecutor<Do> = async (op) => {
+const doEx: OperationExecutor<Do> = async (op, context) => {
   try {
-    const [err] = await to(op.run(op.context));
-    if (err) return await handleError(op, err);
+    const [err] = await to(op.run(context));
+    if (err) return await handleError(op, err, context);
   } catch (err) {
-    return await handleError(op, err);
+    return await handleError(op, err, context);
   }
 };
 
-export const execute = async (operations: Operation[]) => {
+export const execute = async (operations: Operation[], context: Context) => {
   for (let operation of operations) {
     let result = await matchOn("type", operation, {
-      validate: (op) => validate(op),
-      update: (op) => update(op),
-      load: (op) => load(op),
-      match: (op) => match(op),
-      do: (op) => doEx(op),
+      validate: (op) => validate(op, context),
+      update: (op) => update(op, context),
+      load: (op) => load(op, context),
+      match: (op) => match(op, context),
+      do: (op) => doEx(op, context),
       _: (op) => {
         throw createError(
           op.stackSource,
@@ -170,5 +173,6 @@ export const execute = async (operations: Operation[]) => {
 };
 
 type OperationExecutor<O extends Operation> = (
-  op: O
+  op: O,
+  context: Context
 ) => Promise<void | string | Error>;

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -55,5 +55,4 @@ interface BaseOperation {
    * triggering the error, not from the process it's being called in.
    */
   stackSource: StackTracey;
-  context: Context;
 }

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -19,7 +19,6 @@ export class Procedure<C extends Record<string, unknown>> {
       type: "validate",
       run: validateFn,
       argKey: key,
-      context: this.context,
       stackSource: new StackTracey().slice(1),
     });
     return this;
@@ -37,7 +36,6 @@ export class Procedure<C extends Record<string, unknown>> {
       type: "update",
       run: updateFn,
       argKey: key,
-      context: this.context,
       stackSource: new StackTracey().slice(1),
     });
     return this;
@@ -52,7 +50,6 @@ export class Procedure<C extends Record<string, unknown>> {
       procedure: this.name,
       type: "load",
       run: loadFn,
-      context: this.context,
       stackSource: new StackTracey().slice(1),
     });
     return this;
@@ -63,7 +60,6 @@ export class Procedure<C extends Record<string, unknown>> {
       procedure: this.name,
       type: "do",
       run: doFn,
-      context: this.context,
       stackSource: new StackTracey().slice(1),
     });
     return this;
@@ -92,7 +88,6 @@ export class Procedure<C extends Record<string, unknown>> {
       type: "match",
       statements,
       otherwise,
-      context: this.context,
       stackSource: new StackTracey().slice(1),
     });
     return this;
@@ -103,15 +98,14 @@ export class ProcedureWithEagerContext<
   C extends Record<string, unknown>
 > extends Procedure<C> {
   exec() {
-    return execute(this.operations);
+    return execute(this.operations, this.context);
   }
 }
 export class ProcedureWithLazyContext<
   C extends Record<string, unknown>
 > extends Procedure<C> {
   exec(context: C) {
-    Object.assign(this.context, context);
-    return execute(this.operations);
+    return execute(this.operations, context);
   }
 }
 


### PR DESCRIPTION
Two things here:

1. attaching the context directly to an operation caused some scoping/timing access problems. Instead of that the context is passed directly down to the executors.
2. some error messages were missing stack traces. If there's no extra details on an error message (meaning it wasn't custom) then I'm just including the original stack trace. 