### PR TITLE
Allow `do` to execute procedures passed to it

### DIFF
--- a/src/executors.ts
+++ b/src/executors.ts
@@ -143,7 +143,9 @@ const match: OperationExecutor<Match> = async (op, context) => {
 
 const doEx: OperationExecutor<Do> = async (op, context) => {
   try {
-    const [err] = await to(op.run(context));
+    const [err] = await to(
+      op.run instanceof Procedure ? op.run.exec(context) : op.run(context)
+    );
     if (err) return await handleError(op, err, context);
   } catch (err) {
     return await handleError(op, err, context);

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -38,7 +38,9 @@ export interface Match extends BaseOperation {
 
 export interface Do extends BaseOperation {
   type: "do";
-  run: (context: any) => void | Promise<void>;
+  run:
+    | ProcedureWithLazyContext<Partial<any>>
+    | ((context: any) => void | Promise<void>);
 }
 
 export interface GoTo extends BaseOperation {

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -55,7 +55,11 @@ export class Procedure<C extends Record<string, unknown>> {
     return this;
   }
 
-  do(doFn: (context: C) => void | Promise<void>) {
+  do(
+    doFn:
+      | ProcedureWithLazyContext<Partial<C>>
+      | ((context: C) => void | Promise<void>)
+  ) {
     this.operations.push({
       procedure: this.name,
       type: "do",

--- a/tests/do.test.ts
+++ b/tests/do.test.ts
@@ -1,10 +1,16 @@
-import { procedure } from '../src/procedure'
+import { procedure } from "../src/procedure";
 
 it("should run something on do", async () => {
-  let context = { foo: 'bar' }
+  let context = { foo: "bar" };
   let doFn = jest.fn();
-  await procedure('test', context)
-    .do(doFn)
-    .exec()
-  expect(doFn).toBeCalledWith(context)
-})
+  await procedure("test", context).do(doFn).exec();
+  expect(doFn).toBeCalledWith(context);
+});
+
+it("should run a nested procedure", async () => {
+  const context = {};
+  let action = jest.fn();
+  const childProc = procedure("child").do(action);
+  await procedure("parent").do(childProc).exec(context);
+  expect(action).toBeCalledWith(context);
+});


### PR DESCRIPTION
I ran into a case where I'd like to execute a nested procedure. I'd already added similar functionality inside of `match` and ultimately most of the operations should accept procedures as well as functions. 

Here's what this looks like: 

```ts
// First we'll define a procedure to be passed into `do`
const nestedProcedure = procedure("nested procedure").do(something);

// Then we'll call the procedure w/ do
await procedure('parent procedure').do(nestedProcedure).exec({});
```