### PR TITLE
Allow specifying context defaults

### DIFF
--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,6 +1,6 @@
 import StackTracey from "stacktracey";
 import { Context } from "./context";
-import { ProcedureWithLazyContext } from "./procedure";
+import { Procedure } from "./procedure";
 
 export type Operation = Validate | Update | Load | Match | Do | GoTo;
 
@@ -23,7 +23,7 @@ export interface Load extends BaseOperation {
 
 export type MatchCondition<C> = (context: C) => boolean | Promise<boolean>;
 export type MatchAction<C extends Context> =
-  | ProcedureWithLazyContext<Partial<C>>
+  | Procedure<Partial<C>>
   | ((context: C) => void | Partial<C> | Promise<void | Partial<C>>);
 
 export type MatchStatement<C extends Context> = [
@@ -38,9 +38,7 @@ export interface Match extends BaseOperation {
 
 export interface Do extends BaseOperation {
   type: "do";
-  run:
-    | ProcedureWithLazyContext<Partial<any>>
-    | ((context: any) => void | Promise<void>);
+  run: Procedure<Partial<any>> | ((context: any) => void | Promise<void>);
 }
 
 export interface GoTo extends BaseOperation {

--- a/tests/do.test.ts
+++ b/tests/do.test.ts
@@ -3,7 +3,7 @@ import { procedure } from "../src/procedure";
 it("should run something on do", async () => {
   let context = { foo: "bar" };
   let doFn = jest.fn();
-  await procedure("test", context).do(doFn).exec();
+  await procedure("test").do(doFn).exec(context);
   expect(doFn).toBeCalledWith(context);
 });
 

--- a/tests/load.test.ts
+++ b/tests/load.test.ts
@@ -1,9 +1,9 @@
-import { procedure } from '../src/procedure'
+import { procedure } from "../src/procedure";
 
 it("should update context when successfully loading", async () => {
-  let context = { foo: 'bar' }
-  await procedure('test', context)
-    .load((c) => ({ foo: 'baz' }))
-    .exec()
-  expect(context.foo).toBe('baz')
-})
+  let context = { foo: "bar" };
+  await procedure("test")
+    .load((c) => ({ foo: "baz" }))
+    .exec(context);
+  expect(context.foo).toBe("baz");
+});

--- a/tests/match.test.ts
+++ b/tests/match.test.ts
@@ -5,21 +5,21 @@ const fooHasNoBar = ({ foo }: any) => foo !== "bar";
 
 it("matches on simple case", async () => {
   const testPassed = jest.fn();
-  await procedure("match test", { foo: "bar" })
+  await procedure("match test")
     .match([[fooHasBar, testPassed]])
-    .exec();
+    .exec({ foo: "bar" });
   expect(testPassed).toBeCalled();
 });
 
 it("matches on multiple cases", async () => {
   const testPassed = jest.fn();
   const testFailed = jest.fn();
-  await procedure("match test", { foo: "bar" })
+  await procedure("match test")
     .match([
       [fooHasNoBar, testFailed],
       [fooHasBar, testPassed],
     ])
-    .exec();
+    .exec({ foo: "bar" });
   expect(testPassed).toBeCalled();
   expect(testFailed).not.toBeCalled();
 });
@@ -27,7 +27,7 @@ it("matches on multiple cases", async () => {
 it("matches on first case without calling others", async () => {
   const testPassed = jest.fn();
   const testFailed = jest.fn();
-  await procedure("match test", { foo: "bar" })
+  await procedure("match test")
     .match(
       [
         [fooHasBar, testPassed],
@@ -35,7 +35,7 @@ it("matches on first case without calling others", async () => {
       ],
       testFailed
     )
-    .exec();
+    .exec({ foo: "bar" });
   expect(testPassed).toBeCalled();
   expect(testFailed).not.toBeCalled();
 });
@@ -43,7 +43,7 @@ it("matches on first case without calling others", async () => {
 it("uses fallback if one supplied and no other matches", async () => {
   const testPassed = jest.fn();
   const testFailed = jest.fn();
-  await procedure("match test", { foo: "bar" })
+  await procedure("match test")
     .match(
       [
         [fooHasNoBar, testFailed],
@@ -51,7 +51,7 @@ it("uses fallback if one supplied and no other matches", async () => {
       ],
       testPassed
     )
-    .exec();
+    .exec({ foo: "bar" });
   expect(testPassed).toBeCalled();
   expect(testFailed).not.toBeCalled();
 });
@@ -59,17 +59,17 @@ it("uses fallback if one supplied and no other matches", async () => {
 it("errors if no case matches without fallback", async () => {
   const testFailed = jest.fn();
   await expect(
-    procedure("match test", { foo: "bar" })
+    procedure("match test")
       .match([
         [fooHasNoBar, testFailed],
         [fooHasNoBar, testFailed],
       ])
-      .exec()
+      .exec({ foo: "bar" })
   ).rejects.toMatchInlineSnapshot(`
           [ProcedureError: Unhandled Internal Exception
 
             61 |   await expect(
-            62 |     procedure("match test", { foo: "bar" })
+            62 |     procedure("match test")
           > 63 |       .match([
                |        ^ Match statement unhandled, add a fallback
             64 |         [fooHasNoBar, testFailed],

--- a/tests/or.test.ts
+++ b/tests/or.test.ts
@@ -1,12 +1,14 @@
-import { procedure } from '../src/procedure'
+import { procedure } from "../src/procedure";
 
 it("should handle errors from do", async () => {
   const context = {};
-  const err = "err"
+  const err = "err";
   const orFn = jest.fn().mockImplementation(() => {});
-  await procedure('do test', context)
-    .do(() => { throw err })
+  await procedure("do test")
+    .do(() => {
+      throw err;
+    })
     .or(orFn)
-    .exec()
-  expect(orFn).toBeCalledWith(err, context)
-})
+    .exec(context);
+  expect(orFn).toBeCalledWith(err, context);
+});

--- a/tests/procedure.test.ts
+++ b/tests/procedure.test.ts
@@ -1,0 +1,41 @@
+import { procedure } from "../src/procedure";
+
+it("allows specifying default partial context on creation", async () => {
+  type Context = {
+    foo: string;
+    works: boolean;
+  };
+  const defaults: Partial<Context> = {
+    foo: "bar",
+  };
+
+  const doFn = jest.fn();
+
+  await procedure<Context, typeof defaults>("test", defaults)
+    .do(doFn)
+    .exec({ works: true });
+
+  expect(doFn).toBeCalledWith({
+    foo: "bar",
+    works: true,
+  });
+});
+
+it("overrides default partial context", async () => {
+  type Context = {
+    foo: string;
+  };
+  const defaults: Partial<Context> = {
+    foo: "bar",
+  };
+
+  const doFn = jest.fn();
+
+  await procedure<Context, typeof defaults>("test", defaults)
+    .do(doFn)
+    .exec({ foo: "baz" });
+
+  expect(doFn).toBeCalledWith({
+    foo: "baz",
+  });
+});

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,9 +1,9 @@
 import { procedure } from "../src/procedure";
 
 it("updates a context value", async () => {
-  const context = { foo: 'bar' }
-  await procedure('update test', context)
-    .update('foo', () => 'baz')
-    .exec();
-  expect(context.foo).toBe('baz')
+  const context = { foo: "bar" };
+  await procedure("update test")
+    .update("foo", () => "baz")
+    .exec(context);
+  expect(context.foo).toBe("baz");
 });

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -2,28 +2,28 @@ import { procedure } from "../src/procedure";
 
 it("resolves when a validation is successful", async () => {
   await expect(
-    procedure("test", { test: true })
+    procedure("test")
       .validate("test", (t) => t === true)
-      .exec()
+      .exec({ test: true })
   ).resolves.toBeUndefined();
 });
 
 it("rejects when a validation is unsuccessful", async () => {
   const isTestValid = (t) => t === false;
   await expect(
-    procedure("test", { test: true }).validate("test", isTestValid).exec()
+    procedure("test").validate("test", isTestValid).exec({ test: true })
   ).rejects.toMatchInlineSnapshot(`
           [ProcedureError: Unhandled Internal Exception
 
             12 |   const isTestValid = (t) => t === false;
             13 |   await expect(
-          > 14 |     procedure("test", { test: true }).validate("test", isTestValid).exec()
-               |                                       ^ test is invalid according to isTestValid
+          > 14 |     procedure("test").validate("test", isTestValid).exec({ test: true })
+               |                       ^ test is invalid according to isTestValid
             15 |   ).rejects.toMatchInlineSnapshot(\`
             16 |           [ProcedureError: Unhandled Internal Exception
             17 |
 
-          tests/validate.test.ts:14:39
+          tests/validate.test.ts:14:23
 
           ]
         `);


### PR DESCRIPTION
Fixes #7

This is a breaking change. 

This allows one to specify a default set of values when creating a procedure to prepopulate the context. 