### PR TITLE
Refactor for better typing behavior on context

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Writing scripts or cli tools that need to take a lot of procedural actions can often be quite verbose. It can be hard to glance at that code and try to fit what it's doing in your head. That's usually an indicator that it needs to be broken down, but finding a way to break it down and retrain a central narrative isn't the easiest thing to accomplish on the first pass.
 
-`procedure` seeks to help by providing a simple, deferred scaffolding for building complex procedural flows. The whole intent is to make your code as terse and readable as possible.
+`procedure` seeks to help by providing a simple DSL for building complex procedural flows. The whole intent is to make your code as terse and readable as possible.
 
 ## Anatomy of a procedure
 
@@ -13,26 +13,19 @@ Any procedure starts with calling the `procedure` function with a name and optio
 ```
 import { procedure } from "@zephraph/procedure"
 
-type Context {
-  aDefaultValue: boolean;
-  aValueToBeSetOnExecution: string;
-}
-
-const defaults = {
-  aDefaultValue: true
-}
-
-// Note if you use the second argument and want it type-checked you _must_ manually pass in the types as shown
-procedure<Context, typeof defaults>('my test procedure', defaults)
+await procedure('my test procedure', { greeting: 'hello world!' })
+  .do(({ greeting }) => console.log(greeting))
+  .exec()
 ```
 
 Once you have a procedure defined, there are a few methods you can chain onto it do perform generic actions or update the context.
 
 - `load` -- Takes a function that's given `context`, can be sync or async, and returns a partial to be written to `context`
-- `validate` -- Takes a function that's given a key of `context` and the corresponding value and returns `true`/`false` depending on if the value is valid
-- `update` -- Takes a function that's given a value to update and the context and expected to return a new value.
+- `validate` -- Takes a function that's given a key of `context` and the corresponding value and returns `true`/`false` depending on if the value is valid.
+- `update` -- Takes a function that's given a value to update and the context and expected to return a new value. The value must be of the same type.
 - `match` -- A robust mechanism for performing conditional operations. It takes an array of what I'm terming `MatchStatements`. Each statement is made up of one or more case statements that take the `context` and return `true`/`false` if the case is met. The last item in the array is an action statement that's called if all the previous case statements are `true`. A match operation may also be provided with a secondary argument that's a generic action that can be ran if no match statement resolves.
 - `do` -- Represents a generic operation. It takes a function which receives `context` and... does something.
+- `or` -- Used to gracefully handle errors when some other action can be taken.
 
 All of the above methods are _lazy_. When you chain them onto `procedure` all they do is collect in the `procedure`'s internal operation list.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/esm/index.js",
   "types": "dist/index.d.js",
   "author": {
-    "email": "zephraph@gmail.com",
+    "email": "oss@just-be.dev",
     "name": "Justin Bennett",
     "url": "https://just-be.dev"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "dependencies": {
     "endent": "^2.0.1",
     "stacktracey": "^2.1.7",
-    "ts-union-tools": "^0.0.1"
+    "ts-pattern": "^4.0.6",
+    "ts-union-tools": "^0.0.1",
+    "type-fest": "^3.3.0"
   },
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "endent": "^2.0.1",
     "stacktracey": "^2.1.7",
     "ts-pattern": "^4.0.6",
-    "ts-union-tools": "^0.0.1",
     "type-fest": "^3.3.0"
   },
   "license": "MIT",

--- a/src/error.ts
+++ b/src/error.ts
@@ -2,7 +2,6 @@ import { codeFrameColumns } from "@babel/code-frame";
 import StackTracey from "stacktracey";
 import { yellow, bold, dim, red } from "chalk";
 import { Context } from "./context";
-import { Operation } from "./operations";
 import { parseMatch } from "./parsers";
 import { style } from "./utils";
 import asTable from "as-table";
@@ -24,7 +23,7 @@ export const ERROR = {
   UNKNOWN_ERR: "unknown-error",
   NO_MATCH: "unmatched-value",
   RUNTIME_ERR: "runtime-error",
-  INVALID: <C extends Context>(key: keyof C) => `validate-error:${key}`,
+  INVALID: <C extends Context>(key: keyof C) => `validate-error:${String(key)}`,
   MATCH_CHECK_ERR: (check: string) => `match-check-error:${check}`,
 } as const;
 
@@ -47,34 +46,33 @@ export const createError = (
   const sourceTrace = trace.withSource(trace.items[0]);
   const lines = sourceTrace.sourceFile?.text;
   const header = `Unhandled Internal Exception\n\n`;
-  let footer = `\n\n${
-    (errTrace &&
-      "which...\n" +
-        asTable(
-          errTrace.items
-            .map((item, index) =>
-              index === 0
-                ? [
-                    style(
-                      `  ${style("failed:", red)} ${item.calleeShort}`,
-                      bold
-                    ),
-                    style(item.fileShort + formatFilePosition(item), bold),
-                  ]
-                : [
-                    `  called: ${item.calleeShort}`,
-                    item.fileShort + formatFilePosition(item),
-                  ]
-            )
-            .reverse()
-        ) +
-        `\n${" ".repeat(10)}${style(
-          "^".repeat(errTrace.items[0].calleeShort.split(" ")[0].length),
-          bold,
-          red
-        )}️ ${style("this threw the exception", bold, yellow)}`) ||
+  let footer = `\n\n${(errTrace &&
+    "which...\n" +
+    asTable(
+      errTrace.items
+        .map((item, index) =>
+          index === 0
+            ? [
+              style(
+                `  ${style("failed:", red)} ${item.calleeShort}`,
+                bold
+              ),
+              style(item.fileShort + formatFilePosition(item), bold),
+            ]
+            : [
+              `  called: ${item.calleeShort}`,
+              item.fileShort + formatFilePosition(item),
+            ]
+        )
+        .reverse()
+    ) +
+    `\n${" ".repeat(10)}${style(
+      "^".repeat(errTrace.items[0].calleeShort.split(" ")[0].length),
+      bold,
+      red
+    )}️ ${style("this threw the exception", bold, yellow)}`) ||
     ""
-  }`;
+    }`;
 
   const message = err instanceof Error ? err.message.split("\n")[0] : err;
 
@@ -83,24 +81,24 @@ export const createError = (
 
   return new ProcedureError(
     header +
-      codeFrameColumns(
-        lines!,
-        {
-          start: {
-            line,
-            column,
-          },
+    codeFrameColumns(
+      lines!,
+      {
+        start: {
+          line,
+          column,
         },
-        {
-          message,
-          highlightCode: process.env.NODE_ENV === "test" ? false : true,
-        }
-      ) +
-      `\n\n${style(
-        `${sourceTrace.fileRelative}${formatFilePosition(sourceTrace)}`,
-        dim
-      )}` +
-      footer,
+      },
+      {
+        message,
+        highlightCode: process.env.NODE_ENV === "test" ? false : true,
+      }
+    ) +
+    `\n\n${style(
+      `${sourceTrace.fileRelative}${formatFilePosition(sourceTrace)}`,
+      dim
+    )}` +
+    footer,
     code
   );
 };
@@ -139,27 +137,27 @@ export const createMatchError = (
 
   return new ProcedureError(
     header +
-      codeFrameColumns(
-        text,
-        {
-          start: {
-            line,
-            column,
-          },
-          end: {
-            line,
-            column: column + length,
-          },
+    codeFrameColumns(
+      text,
+      {
+        start: {
+          line,
+          column,
         },
-        {
-          message,
-          highlightCode: process.env.NODE_ENV === "test" ? false : true,
-        }
-      ) +
-      `\n\n${style(`${stack.fileRelative}:${line}:${column}`, dim)}\n\n` +
-      footer +
-      // dim("\n───────────────────────────────────────────────") +
-      details,
+        end: {
+          line,
+          column: column + length,
+        },
+      },
+      {
+        message,
+        highlightCode: process.env.NODE_ENV === "test" ? false : true,
+      }
+    ) +
+    `\n\n${style(`${stack.fileRelative}:${line}:${column}`, dim)}\n\n` +
+    footer +
+    // dim("\n───────────────────────────────────────────────") +
+    details,
     code
   );
 };

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -23,7 +23,7 @@ export interface Load extends BaseOperation {
 
 export type MatchCondition<C> = (context: C) => boolean | Promise<boolean>;
 export type MatchAction<C extends Context> =
-  | Procedure<Partial<C>>
+  | Procedure<Context>
   | ((context: C) => void | Partial<C> | Promise<void | Partial<C>>);
 
 export type MatchStatement<C extends Context> = [

--- a/tests/load.test.ts
+++ b/tests/load.test.ts
@@ -1,9 +1,7 @@
 import { procedure } from "../src/procedure";
 
 it("should update context when successfully loading", async () => {
-  let context = { foo: "bar" };
-  await procedure("test")
-    .load((c) => ({ foo: "baz" }))
-    .exec(context);
-  expect(context.foo).toBe("baz");
+  await expect(procedure("test", { foo: 'bull' })
+    .load(() => ({ foo: "baz" }))
+    .exec()).resolves.toStrictEqual({ foo: "baz" });
 });

--- a/tests/or.test.ts
+++ b/tests/or.test.ts
@@ -3,7 +3,7 @@ import { procedure } from "../src/procedure";
 it("should handle errors from do", async () => {
   const context = {};
   const err = "err";
-  const orFn = jest.fn().mockImplementation(() => {});
+  const orFn = jest.fn().mockImplementation(() => { });
   await procedure("do test")
     .do(() => {
       throw err;

--- a/tests/procedure.test.ts
+++ b/tests/procedure.test.ts
@@ -11,7 +11,7 @@ it("allows specifying default partial context on creation", async () => {
 
   const doFn = jest.fn();
 
-  await procedure<Context, typeof defaults>("test", defaults)
+  await procedure("test", defaults)
     .do(doFn)
     .exec({ works: true });
 
@@ -25,13 +25,13 @@ it("overrides default partial context", async () => {
   type Context = {
     foo: string;
   };
-  const defaults: Partial<Context> = {
+  const defaults = {
     foo: "bar",
   };
 
   const doFn = jest.fn();
 
-  await procedure<Context, typeof defaults>("test", defaults)
+  await procedure<Context>("test", defaults)
     .do(doFn)
     .exec({ foo: "baz" });
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,9 +1,7 @@
 import { procedure } from "../src/procedure";
 
 it("updates a context value", async () => {
-  const context = { foo: "bar" };
-  await procedure("update test")
+  await expect(procedure("update test", { foo: 'bar' })
     .update("foo", () => "baz")
-    .exec(context);
-  expect(context.foo).toBe("baz");
+    .exec()).resolves.toEqual({ foo: "baz" });
 });

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -2,28 +2,28 @@ import { procedure } from "../src/procedure";
 
 it("resolves when a validation is successful", async () => {
   await expect(
-    procedure("test")
+    procedure("test", { test: true })
       .validate("test", (t) => t === true)
-      .exec({ test: true })
-  ).resolves.toBeUndefined();
+      .exec()
+  ).resolves.toStrictEqual({ test: true });
 });
 
 it("rejects when a validation is unsuccessful", async () => {
   const isTestValid = (t) => t === false;
   await expect(
-    procedure("test").validate("test", isTestValid).exec({ test: true })
+    procedure("test", { test: true }).validate("test", isTestValid).exec()
   ).rejects.toMatchInlineSnapshot(`
           [ProcedureError: Unhandled Internal Exception
 
             12 |   const isTestValid = (t) => t === false;
             13 |   await expect(
-          > 14 |     procedure("test").validate("test", isTestValid).exec({ test: true })
-               |                       ^ test is invalid according to isTestValid
+          > 14 |     procedure("test", { test: true }).validate("test", isTestValid).exec()
+               |                                       ^ test is invalid according to isTestValid
             15 |   ).rejects.toMatchInlineSnapshot(\`
             16 |           [ProcedureError: Unhandled Internal Exception
             17 |
 
-          tests/validate.test.ts:14:23
+          tests/validate.test.ts:14:39
 
           ]
         `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3520,11 +3520,6 @@ ts-pattern@^4.0.6:
   resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-4.0.6.tgz#02b17695f6385fcc6d2f3ba7962b0952f709d348"
   integrity sha512-sFHQYD4KoysBi7e7a2mzDPvRBeqA4w+vEyRE+P5MU9VLq8eEYxgKCgD9RNEAT+itGRWUTYN+hry94GDPLb1/Yw==
 
-ts-union-tools@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/ts-union-tools/-/ts-union-tools-0.0.1.tgz#ebe59afacbf5c5ac67b57f4ed9d0dd4c39afe605"
-  integrity sha512-fUrofYJnqbT2Uw5cyJymPcbuVgVgduepTm5Uc3yf/Izc7JKGM49aSz2qxOmvKpM2Y9+9Sv7MV5bCGptJzq6QFQ==
-
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3515,6 +3515,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+ts-pattern@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-4.0.6.tgz#02b17695f6385fcc6d2f3ba7962b0952f709d348"
+  integrity sha512-sFHQYD4KoysBi7e7a2mzDPvRBeqA4w+vEyRE+P5MU9VLq8eEYxgKCgD9RNEAT+itGRWUTYN+hry94GDPLb1/Yw==
+
 ts-union-tools@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/ts-union-tools/-/ts-union-tools-0.0.1.tgz#ebe59afacbf5c5ac67b57f4ed9d0dd4c39afe605"
@@ -3558,6 +3563,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.3.0.tgz#3378c9664eecfd1eb4f0522b13cb0630bc1ec044"
+  integrity sha512-gezeeOIZyQLGW5uuCeEnXF1aXmtt2afKspXz3YqoOcZ3l/YMJq1pujvgT+cz/Nw1O/7q/kSav5fihJHsC/AOUg==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
## Changes

- The `context` type now builds up correctly from the initial context passed to the procedure all the way through every chained method. 
- Minor dependency cleanup

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1--canary.10.d77c915.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @zephraph/procedure@1.0.1--canary.10.d77c915.0
  # or 
  yarn add @zephraph/procedure@1.0.1--canary.10.d77c915.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
